### PR TITLE
Allow SMTP to be sent in addition to Sendgrid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@sendgrid/mail": "^8.1.4"
+        "@sendgrid/mail": "^8.1.4",
+        "nodemailer": "^6.9.16"
       },
       "devDependencies": {
         "@eslint/js": "^9.13.0",
@@ -2228,6 +2229,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.9.16",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.16.tgz",
+      "integrity": "sha512-psAuZdTIRN08HKVd/E8ObdV6NO7NTBY3KsC30F7M4H1OnmLCUNaS56FpYxyb26zWLSyYF9Ozch9KYHhHegsiOQ==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/object-inspect": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "typescript-eslint": "^8.11.0"
   },
   "dependencies": {
-    "@sendgrid/mail": "^8.1.4"
+    "@sendgrid/mail": "^8.1.4",
+    "nodemailer": "^6.9.16"
   }
 }


### PR DESCRIPTION
This adds SMTP support for email sending, this could work better for some users. Or for users that already have an SMTP server setup or prefer the self hosted option.