### PR TITLE
Allow for multiple receiver emails

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -130,17 +130,19 @@ function formatTmdbResponse(response: any): TmdbResponse {
 
 async function sendSendgridEmail(formattedResponse: TmdbResponse) {
   sgMail.setApiKey(process.env.SENDGRID_API_KEY)
+
+  const receiverEmails = (process.env.SENDGRID_RECEIVER_EMAIL || "")
+  .replace(/\s/g, "")
+  .split(",")
+  .map((email: string) => ({ email: email }))
+
   const msg = {
     from: {
       email: process.env.SENDGRID_SENDER_EMAIL,
     },
     personalizations: [
       {
-        to: [
-          {
-            email: process.env.SENDGRID_RECEIVER_EMAIL,
-          },
-        ],
+        to: receiverEmails, // array of objects with email key and value
         dynamic_template_data: {
           title: formattedResponse.title,
           releaseDate: formattedResponse.releaseDate,


### PR DESCRIPTION
This commit allows for multiple receiver emails to be specified in the SENDGRID_RECEIVER_EMAIL environment variable. The emails should be separated by commas. The emails are then split by commas and mapped to an array of objects with the email key and value.

SENDGRID_RECEIVER_EMAIL=email1@mail.com, email2@mail.com