### PR TITLE
Split the sending of emails into different routes

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -1,12 +1,12 @@
 TMDB_API_KEY=
 
-MAIL_PROVIDER= # if set to smtp, it will use the SMTP configuration or else it will use the SendGrid configuration
-
+# Needed to hit /item-added or /item-added/sendgrid
 SENDGRID_API_KEY=
 SENDGRID_SENDER_EMAIL=
 SENDGRID_RECEIVER_EMAIL=
 SENDGRID_TEMPLATE_ID= # The Dynamic template ID from SendGrid
 
+# Needed to hit /item-added or /item-added/smtp
 SMTP_HOST=
 SMTP_PORT= # will default to 587 if not set
 SMTP_SENDER_EMAIL=

--- a/src/routes/itemAdded.ts
+++ b/src/routes/itemAdded.ts
@@ -5,7 +5,7 @@ import { getTmdbData } from "../services/tmdbService"
 
 const router = express.Router()
 
-router.post("/", async (req: Request, res: Response) => {
+router.post(["/", "/sendgrid"], async (req: Request, res: Response) => {
   console.log(req.headers, req.body)
   if (!req.body.Provider_tmdb) {
     res
@@ -24,26 +24,45 @@ router.post("/", async (req: Request, res: Response) => {
     return
   }
 
-  if (process.env.MAIL_PROVIDER?.toLowerCase() === "smtp") {
-    try {
-      await sendSMTPEmail(tmdbResponse)
-    } catch (error: any) {
-      res.status(500).json({ smtpErrors: error })
-      return
-    }
-  } else {
-    try {
-      await sendSendgridEmail(tmdbResponse)
-    } catch (error: any) {
-      res
-        .status(error.code)
-        .json({ sendgridErrors: error.response.body.errors })
-      return
-    }
+  try {
+    await sendSendgridEmail(tmdbResponse)
+  } catch (error: any) {
+    res.status(error.code).json({ sendgridErrors: error.response.body.errors })
+    return
   }
   res
     .status(200)
     .json({ message: "Email successfully delivered", data: tmdbResponse })
 })
 
+router.post("/smtp", async (req: Request, res: Response) => {
+  console.log(req.headers, req.body)
+  if (!req.body.Provider_tmdb) {
+    res
+      .status(400)
+      .json({ message: "TMDB ID not found in body (Provider_tmdb)" })
+    return
+  }
+
+  let tmdbResponse
+  try {
+    tmdbResponse = await getTmdbData(req.body.Provider_tmdb)
+  } catch (error: any) {
+    res
+      .status(error.status)
+      .json({ message: "Unable to get details from TMDB", tmdbErrors: error })
+    return
+  }
+
+  try {
+    await sendSMTPEmail(tmdbResponse)
+  } catch (error: any) {
+    res.status(500).json({ smtpErrors: error })
+    return
+  }
+
+  res
+    .status(200)
+    .json({ message: "Email successfully delivered", data: tmdbResponse })
+})
 export default router


### PR DESCRIPTION
This separates the sending for SMTP and for Sendgrid. This will also help if this project will be expanded to include more email providers and will help for those self hosting.