### PR TITLE
Read emails from the request body

### DIFF
--- a/src/config/tmdbConfig.ts
+++ b/src/config/tmdbConfig.ts
@@ -19,6 +19,7 @@ export interface TmdbResponse {
   movieUrl: string
   tvUrl: string
   imdbUrl: string
+  emails: string
 }
 
 export const tmdbData: TmdbBaseData = {

--- a/src/routes/itemAdded.ts
+++ b/src/routes/itemAdded.ts
@@ -12,9 +12,7 @@ router.post(["/", "/sendgrid"], async (req: Request, res: Response) => {
   try {
     tmdbResponse = await getTmdbData(req.body)
   } catch (error: any) {
-    res
-      .status(error.status)
-      .json({ tmdbErrors: error })
+    res.status(error.status).json({ tmdbErrors: error })
     return
   }
 

--- a/src/services/sendgridService.ts
+++ b/src/services/sendgridService.ts
@@ -4,7 +4,7 @@ import { TmdbResponse } from "../config/tmdbConfig"
 export async function sendSendgridEmail(formattedResponse: TmdbResponse) {
   sgMail.setApiKey(process.env.SENDGRID_API_KEY)
 
-  const receiverEmails = (process.env.SENDGRID_RECEIVER_EMAIL || "")
+  const receiverEmails = ( formattedResponse.emails || process.env.SENDGRID_RECEIVER_EMAIL || "")
     .replace(/\s/g, "")
     .split(",")
     .map((email: string) => ({ email: email }))

--- a/src/services/tmdbService.ts
+++ b/src/services/tmdbService.ts
@@ -29,10 +29,10 @@ export async function getTmdbData(requestBody: any) {
     return response.json()
   })
 
-  return formatTmdbResponse(tmdbResponse)
+  return formatTmdbResponse(tmdbResponse, requestBody.emails)
 }
 
-export function formatTmdbResponse(response: any): TmdbResponse {
+export function formatTmdbResponse(response: any, emails: string): TmdbResponse {
   return {
     genres: response.genres
       .map((genre: { id: number; name: string }) => genre.name)
@@ -48,5 +48,6 @@ export function formatTmdbResponse(response: any): TmdbResponse {
     movieUrl: `${tmdbData.movieUrl}${response.id}`,
     tvUrl: `${tmdbData.tvUrl}${response.id}`,
     imdbUrl: `${tmdbData.imdbUrl}${response.imdb_id}`,
+    emails: emails,
   }
 }


### PR DESCRIPTION
This will allow the user to send emails to multiple recipients by adding a new field to the request body handlebars. This takes precedence over any environment variable that might be set. I like this approach better as it allows the user to send emails to different recipients for different filters.

I still would like to refactor the code to make the TMDB response be more suited to be a unique Mailfin response.