### PR TITLE
Use list of emails to support multiple recipients

### DIFF
--- a/src/services/smtpService.ts
+++ b/src/services/smtpService.ts
@@ -4,6 +4,12 @@ import { MailfinResponse } from "../config/mailfinConfig"
 const nodeMailer = require("nodemailer")
 
 export async function sendSMTPEmail(formattedResponse: MailfinResponse) {
+
+  if (!process.env.SMTP_HOST || !process.env.SMTP_AUTH_USER || !process.env.SMTP_AUTH_PASSWORD) {
+    console.error("SMTP configuration is missing. Please check your environment variables.")
+    return
+  }
+
   const transporter = nodeMailer.createTransport({
     host: process.env.SMTP_HOST,
     port: process.env.SMTP_PORT || "587",
@@ -14,8 +20,8 @@ export async function sendSMTPEmail(formattedResponse: MailfinResponse) {
     },
   })
 
-  let subject = ''
-  let html = generateHtmlTemplate(formattedResponse)
+  let subject = ""
+  const html = generateHtmlTemplate(formattedResponse)
   if (formattedResponse.itemType === "Movie") {
     subject = `A new movie has been added to Jellyfin: ${formattedResponse.name} (${formattedResponse.releaseYear})`
   } else if (formattedResponse.itemType === "Season") {
@@ -25,10 +31,17 @@ export async function sendSMTPEmail(formattedResponse: MailfinResponse) {
   } else {
     subject = `A new item has been added to Jellyfin: ${formattedResponse.name}`
   }
-    
+
+  if (!process.env.SMTP_RECEIVER_EMAIL || process.env.SMTP_RECEIVER_EMAIL.trim() === "") {
+    console.error("SMTP receiver email is not configured. Please set the SMTP_RECEIVER_EMAIL environment variable.")
+    return
+  }
+
+  const mailList = process.env.SMTP_RECEIVER_EMAIL?.split(",").map(email => email.trim()).filter(email => email !== "")
+
   const mailOptions = {
     from: process.env.SMTP_SENDER_EMAIL,
-    to: process.env.SMTP_RECEIVER_EMAIL,
+    to: mailList,
     subject: subject,
     html: html,
   }


### PR DESCRIPTION
This makes it so that a user is able to use a comma spaced string in the .env file to specify which addresses to email.